### PR TITLE
Return message to the client

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,7 @@ function isEmpty(obj) {
 MeteorClient.prototype.log = function (level, msg, meta, callback) {
   // @TODO: Make the log message conform better to Winston's own output
   "use strict";
-  var lastMessage = level + ': ' + msg;
+  lastMessage = level + ': ' + msg;
   if (!isEmpty(meta) && JSON.stringify) {
     lastMessage += '\nmeta = ' + JSON.stringify(meta)
   }


### PR DESCRIPTION
The lastMessage Object returned in the meteor method 'winston-client.log' is allways empty because it the log function it is set to a function scoped variable.
Changing this will also write the return value to the console on the client.